### PR TITLE
fix(ci): dockleのciをより安定して動かせるようにする

### DIFF
--- a/.github/workflows/dockle.yml
+++ b/.github/workflows/dockle.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   dockle:
     runs-on: ubuntu-latest
+
     env:
       DOCKER_CONTENT_TRUST: 1
       DOCKLE_VERSION: 0.4.15
@@ -20,29 +21,33 @@ jobs:
 
       - name: Download and install dockle v${{ env.DOCKLE_VERSION }}
         run: |
+          set -eux
           curl -L -o dockle.deb "https://github.com/goodwithtech/dockle/releases/download/v${DOCKLE_VERSION}/dockle_${DOCKLE_VERSION}_Linux-64bit.deb"
           sudo dpkg -i dockle.deb
 
-      - run: |
-          cp .config/docker_example.env .config/docker.env
-          cp ./compose_example.yml ./compose.yml
-
-      - run: |
-          docker compose up -d web
-          IMAGE_ID=$(docker compose images --format json web | jq -r '.[0].ID')
-          docker tag "${IMAGE_ID}" misskey-web:latest
-
-      - name: Prune docker junk (optional but recommended)
+      - name: Build web image (docker build)
         run: |
-          docker system prune -af
-          docker volume prune -f
+          set -eux
+          docker build -t "misskey-web:ci" .
+          docker image ls
 
-      - name: Save image for Dockle
+      - name: Mount tmpfs for Dockle tar
+        env:
+          TMPFS_SIZE: 8G
         run: |
-          docker save misskey-web:latest -o ./misskey-web.tar
-          ls -lh ./misskey-web.tar
+          set -eux
+          sudo mkdir -p /mnt/dockle-tmp
+          sudo mount -t tmpfs -o size=${{ env.TMPFS_SIZE }} tmpfs /mnt/dockle-tmp
+          free -h
+          df -h
 
-      - name: Run Dockle with tar input
+      - name: Save image tar into tmpfs
         run: |
-          dockle --exit-code 1 --input ./misskey-web.tar
+          set -eux
+          docker save misskey-web:ci -o /mnt/dockle-tmp/misskey-web.tar
+          ls -lh /mnt/dockle-tmp/misskey-web.tar
 
+      - name: Run Dockle Scan (tar input)
+        run: |
+          set -eux
+          dockle --exit-code 1 --input /mnt/dockle-tmp/misskey-web.tar


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->

DockleのCIが落ちているのを解消します
- ディスクがカツカツだった（空き容量6GBも無い）
- メモリはかなり余裕があった（10GB以上）
- tmpfsに8GB割り当ててマウントした
- tarをtmpfsに吐き出すようにした（ここで容量問題をクリア）
- dockleからはtmpfsに吐いたtarを読むようにした

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

リリースの妨げになっている

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

本家にも同じパッチを投げる予定でいますが（そのうち顕在化することが予想される）、

- 本家の方は通っているので優先度が下がりがち
- 次のリリースを待たないと取り込みにくい

…などなどの理由から、こちらにも個別でパッチを投げます

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
